### PR TITLE
added default values

### DIFF
--- a/src/api/response/site.rs
+++ b/src/api/response/site.rs
@@ -495,8 +495,10 @@ pub struct Inverter {
 	/// CPU Firmware version e.g. 2.52.311
 	pub cpu_version: String,
 	/// DSP 1 Firmware version
+	#[serde(default)]
 	pub dsp1_version: String,
 	/// DSP 2 Firmware version
+	#[serde(default)]
 	pub dsp2_version: String,
 	/// the communication interface used to connect to server. E.g. Ethernet.
 	pub communication_method: EquipmentCommunicationMethod,
@@ -513,8 +515,10 @@ pub struct Meter {
 	/// the inverter name e.g. "Feed In Meter"
 	pub name: String,
 	/// e.g. "WattNode"
+	#[serde(default)]
 	pub manufacturer: String,
 	/// meter model number
+	#[serde(default)]
 	pub model: String,
 	/// serial number (if applicable)
 	#[serde(rename = "SN")]
@@ -524,9 +528,10 @@ pub struct Meter {
 	/// FirmwareVersion (if applicable)
 	pub firmware_version: Option<String>,
 	/// Name of SolarEdge device the meter is connected to
+	#[serde(default)]
 	pub connected_to: String,
 	/// serial number of the inverter / gateway the meter is connected to
-	#[serde(rename = "connectedSolaredgeDeviceSN")]
+	#[serde(rename = "connectedSolaredgeDeviceSN", default)]
 	pub connected_solaredge_device_sn: String,
 	pub form: MeterForm,
 }


### PR DESCRIPTION
I ran into an issue where deserialization failed when calling `site_inventory` because expected fields were missing from the response. Adding default values for the missing fields fixes the issue in a backwards compatible way.

Specifically I had inverter and meter responses like:
```
[{
  "name": "Inverter 1",
  "manufacturer":"SolarEdge",
  "model":"SE100K-XXXXX",
  "communicationMethod": "ETHERNET",
  "cpuVersion":"4.23.524",
  "connectedOptimizers":56,
  "partNumber":"XXXXXXXX","SN":"XXXXXXXXX"
}]
```
(missing `dsp1Version` and `dsp2Version`)

And meter responses like:
```
[{
  "name":"Consumption Meter",
  "firmwareVersion":"",
  "type":"Consumption",
  "form":"virtual"
  },{
    "name":"Self Consumption",
    "firmwareVersion":"",
    "type":"SelfConsumption",
    "form":"virtual"
}]
```
(missing `manufacturer`, `model`, `connectedTo`, and `connectedSolaredgeDeviceSN`).

Not sure if you want to merge this but figured I'd open the PR anyways. Thanks for maintaining, the crate has been very helpful for me :)

