### PR TITLE
changed field from bool to Option<bool> to prevent deserialization error

### DIFF
--- a/src/api/response/site.rs
+++ b/src/api/response/site.rs
@@ -41,7 +41,7 @@ pub struct Uris {
 #[serde(rename_all = "camelCase")]
 pub struct PublicSettings {
 	pub name: Option<String>,
-	pub is_public: bool,
+	pub is_public: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
I ran into an issue where deserialization failed when calling site_details because [`PublicSettings.is_public`](https://github.com/twistedfall/solaredge/blob/f959ff0bd60fb2f3f34d040d267adab6df0c7924/src/api/response/site.rs#L44) was not the expected boolean type.

Specifically I have api responses like:
```
{
  "details": {
    ...
    "publicSettings": {
      "isPublic": null
    }
  }
}
```

Apologies for opening another one of these so soon.